### PR TITLE
Adding IRI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 ### Added
 
-- League\Uri\Components\Exception as the base exception for the library
+- `League\Uri\Components\Exception` as the base exception for the library
+- `League\Uri\Components\DataPath::getDecoded` returns the non-encoded path
+- `League\Uri\Components\HierarchicalPath::getDecoded` returns the non-encoded path
+- `League\Uri\Components\Path::getDecoded` returns the non-encoded path
+- `League\Uri\Components\Fragment::getDecoded` returns the non-encoded fragment
+- `League\Uri\Components\Port::getDecoded` returns the non-encoded port
+- `League\Uri\Components\Scheme::getDecoded` returns the non-encoded scheme
+- `League\Uri\Components\Query::extract` public static method returns a hash similar to `parse_str` without the mangling from the query string
 
 ### Fixed
 
-- None
+- `getContent` is updated to support RFC3987
 
 ### Deprecated
 
@@ -18,7 +25,8 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 ### Removed
 
-- None
+- `Query::parsed` use `Query::extract` instead
+- `Query::parsedValue` use `Query::extract` instead
 
 ## 0.2.1
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-intl" : "*",
         "ext-fileinfo": "*",
         "jeremykendall/php-domain-parser": "^3.0",
-        "league/uri-interfaces": "^0.1.0"
+        "league/uri-interfaces": "~0.2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.0",

--- a/src/Component.php
+++ b/src/Component.php
@@ -13,6 +13,7 @@
 namespace League\Uri\Components;
 
 use League\Uri\Components\Traits\ImmutableComponent;
+use League\Uri\Interfaces\Component as UriComponent;
 
 /**
  * An abstract class to ease component manipulation
@@ -70,11 +71,38 @@ abstract class Component
     }
 
     /**
-     * The component raw data
+     * Returns the instance content encoded in RFC3986 or RFC3987.
      *
-     * @return mixed
+     * If the instance is defined, the value returned MUST be percent-encoded,
+     * but MUST NOT double-encode any characters depending on the encoding type selected.
+     *
+     * To determine what characters to encode, please refer to RFC 3986, Sections 2 and 3.
+     * or RFC 3987 Section 3.
+     *
+     * By default the content is encoded according to RFC3986
+     *
+     * If the instance is not defined null is returned
+     *
+     * @param string $enc_type
+     *
+     * @return string|null
      */
-    public function getContent()
+    public function getContent($enc_type = UriComponent::RFC3986)
+    {
+        if (!in_array($enc_type, [UriComponent::RFC3986, UriComponent::RFC3987])) {
+            throw new Exception('Unsupported or Unknown Encoding');
+        }
+
+
+        return $this->data;
+    }
+
+    /**
+     * Return the decoded string representation of the component
+     *
+     * @return null|string
+     */
+    public function getDecoded()
     {
         return $this->data;
     }

--- a/src/DataPath.php
+++ b/src/DataPath.php
@@ -114,6 +114,16 @@ class DataPath extends Component implements PathComponent
     }
 
     /**
+     * Return the decoded string representation of the component
+     *
+     * @return string
+     */
+    public function getDecoded()
+    {
+        return $this->data;
+    }
+
+    /**
      * validate the submitted path
      *
      * @param string $path
@@ -335,16 +345,6 @@ class DataPath extends Component implements PathComponent
         $file->fwrite($data);
 
         return $file;
-    }
-
-    /**
-     * Returns the component literal value.
-     *
-     * @return string
-     */
-    public function getContent()
-    {
-        return $this->data;
     }
 
     /**

--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -30,31 +30,47 @@ use League\Uri\Interfaces\Component as UriComponent;
  */
 class Fragment extends Component implements UriComponent
 {
+
     /**
-     * Returns the component literal value
+     * Returns the instance content encoded in RFC3986 or RFC3987.
+     *
+     * If the instance is defined, the value returned MUST be percent-encoded,
+     * but MUST NOT double-encode any characters depending on the encoding type selected.
+     *
+     * To determine what characters to encode, please refer to RFC 3986, Sections 2 and 3.
+     * or RFC 3987 Section 3.
+     *
+     * By default the content is encoded according to RFC3986
+     *
+     * If the instance is not defined null is returned
+     *
+     * @param string $enc_type
      *
      * @return string|null
      */
-    public function getContent()
+    public function getContent($enc_type = self::RFC3986)
     {
-        if (null === $this->data) {
-            return null;
+        if (!in_array($enc_type, [self::RFC3986, self::RFC3987])) {
+            throw new Exception('Unsupported or Unknown Encoding');
         }
 
-        $regexp = '/(?:[^'.self::$unreservedChars.self::$subdelimChars.'\:\/@\?]+
-            |%(?!'.self::$encodedChars.'))/x';
+        if ('' == $this->data) {
+            return $this->data;
+        }
+
+        if (self::RFC3987 == $enc_type) {
+            $pattern = str_split(self::$invalidUriChars);
+
+            return str_replace($pattern, array_map('rawurlencode', $pattern), $this->data);
+        }
+
+        $regexp = '/(?:[^'
+            .self::$unreservedChars
+            .self::$subdelimChars
+            .'\:\/@\?]+|%(?!'
+            .self::$encodedChars.'))/ux';
 
         return $this->encode($this->data, $regexp);
-    }
-
-    /**
-     * Return the decoded string representation of the component
-     *
-     * @return null|string
-     */
-    public function getDecoded()
-    {
-        return $this->data;
     }
 
     /**

--- a/src/HierarchicalComponent.php
+++ b/src/HierarchicalComponent.php
@@ -14,6 +14,7 @@ namespace League\Uri\Components;
 
 use League\Uri\Components\Traits\ImmutableCollection;
 use League\Uri\Components\Traits\ImmutableComponent;
+use League\Uri\Interfaces\Component as UriComponent;
 
 /**
  * An abstract class to ease collection like object manipulation
@@ -83,11 +84,23 @@ abstract class HierarchicalComponent
     }
 
     /**
-     * Returns the component literal value
+     * Returns the instance content encoded in RFC3986 or RFC3987.
+     *
+     * If the instance is defined, the value returned MUST be percent-encoded,
+     * but MUST NOT double-encode any characters depending on the encoding type selected.
+     *
+     * To determine what characters to encode, please refer to RFC 3986, Sections 2 and 3.
+     * or RFC 3987 Section 3.
+     *
+     * By default the content is encoded according to RFC3986
+     *
+     * If the instance is not defined null is returned
+     *
+     * @param string $enc_type
      *
      * @return string|null
      */
-    abstract public function getContent();
+    abstract public function getContent($enc_type = UriComponent::RFC3986);
 
     /**
      * Returns the instance string representation; If the

--- a/src/HierarchicalPath.php
+++ b/src/HierarchicalPath.php
@@ -179,14 +179,6 @@ class HierarchicalPath extends HierarchicalComponent implements PathComponent, C
     /**
      * @inheritdoc
      */
-    public function getContent()
-    {
-        return $this->encodePath($this->getDecoded());
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function __toString()
     {
         return (string) $this->getContent();

--- a/src/Host.php
+++ b/src/Host.php
@@ -326,9 +326,23 @@ class Host extends HierarchicalComponent implements CollectionComponent
     }
 
     /**
-     * @inheritdoc
+     * Returns the instance content encoded in RFC3986 or RFC3987.
+     *
+     * If the instance is defined, the value returned MUST be percent-encoded,
+     * but MUST NOT double-encode any characters depending on the encoding type selected.
+     *
+     * To determine what characters to encode, please refer to RFC 3986, Sections 2 and 3.
+     * or RFC 3987 Section 3.
+     *
+     * By default the content is encoded according to RFC3986
+     *
+     * If the instance is not defined null is returned
+     *
+     * @param string $enc_type
+     *
+     * @return string|null
      */
-    public function getContent()
+    public function getContent($enc_type = self::RFC3986)
     {
         if ([] === $this->data) {
             return null;
@@ -338,7 +352,15 @@ class Host extends HierarchicalComponent implements CollectionComponent
             return $this->data[0];
         }
 
-        return $this->format($this->getLabels(), $this->isAbsolute);
+        if ($enc_type == self::RFC3987) {
+            return $this->format($this->data, $this->isAbsolute);
+        }
+
+        if ($enc_type == self::RFC3986) {
+            return $this->format($this->getLabels(), $this->isAbsolute);
+        }
+
+        throw new Exception('Unsupported or Unknown Encoding');
     }
 
     /**

--- a/src/Path.php
+++ b/src/Path.php
@@ -36,10 +36,12 @@ class Path extends Component implements PathComponent
     }
 
     /**
-     * @inheritdoc
+     * Return the decoded string representation of the component
+     *
+     * @return string
      */
-    public function getContent()
+    public function getDecoded()
     {
-        return $this->encodePath($this->data);
+        return $this->data;
     }
 }

--- a/src/Traits/PathInfo.php
+++ b/src/Traits/PathInfo.php
@@ -13,6 +13,7 @@
 namespace League\Uri\Components\Traits;
 
 use League\Uri\Components\Exception;
+use League\Uri\Interfaces\Component as UriComponent;
 
 /**
  * Value object representing a URI path component.
@@ -78,11 +79,54 @@ trait PathInfo
     }
 
     /**
-     * The component raw data
+     * Returns the instance content encoded in RFC3986 or RFC3987.
      *
-     * @return mixed
+     * If the instance is defined, the value returned MUST be percent-encoded,
+     * but MUST NOT double-encode any characters depending on the encoding type selected.
+     *
+     * To determine what characters to encode, please refer to RFC 3986, Sections 2 and 3.
+     * or RFC 3987 Section 3.
+     *
+     * By default the content is encoded according to RFC3986
+     *
+     * If the instance is not defined null is returned
+     *
+     * @param string $enc_type
+     *
+     * @return string|null
      */
-    abstract public function getContent();
+    public function getContent($enc_type = UriComponent::RFC3986)
+    {
+        if ($enc_type == UriComponent::RFC3987) {
+            $pattern = str_split(self::$invalidUriChars);
+            $pattern[] = '#';
+            $pattern[] = '?';
+
+            return str_replace($pattern, array_map('rawurlencode', $pattern), $this->getDecoded());
+        }
+
+        if ($enc_type == UriComponent::RFC3986) {
+            return $this->encodePath($this->getDecoded());
+        }
+
+        throw new Exception('Unsupported or Unknown Encoding');
+    }
+
+    /**
+     * Encode a path string according to RFC3986
+     *
+     * @param string $str can be a string or an array
+     *
+     * @return string The same type as the input parameter
+     */
+    abstract protected function encodePath($str);
+
+    /**
+     * Return the decoded string representation of the component
+     *
+     * @return string
+     */
+    abstract protected function getDecoded();
 
     /**
      * Returns an instance without dot segments

--- a/test/FragmentTest.php
+++ b/test/FragmentTest.php
@@ -71,6 +71,24 @@ class FragmentTest extends AbstractTestCase
     }
 
     /**
+     * @dataProvider getContentProvider
+     */
+    public function testGetContent($input, $enc_type, $expected)
+    {
+        $this->assertSame($expected, (new Fragment($input))->getContent($enc_type));
+    }
+
+    public function getContentProvider()
+    {
+        return [
+            ['€', Fragment::RFC3987, '€'],
+            ['€', Fragment::RFC3986, '%E2%82%AC'],
+            ['%E2%82%AC', Fragment::RFC3987, '€'],
+            ['%E2%82%AC', Fragment::RFC3986, '%E2%82%AC'],
+        ];
+    }
+
+    /**
      * @param $str
      * @dataProvider failedConstructor
      */
@@ -88,6 +106,12 @@ class FragmentTest extends AbstractTestCase
             'float' => [1.2],
             'array' => [['foo']],
         ];
+    }
+
+    public function testInvalidEncodingTypeThrowException()
+    {
+        $this->expectException(Exception::class);
+        (new Fragment('host'))->getContent('RFC1738');
     }
 
     /**

--- a/test/PathTest.php
+++ b/test/PathTest.php
@@ -35,6 +35,7 @@ class PathTest extends AbstractTestCase
     {
         $path = new Path($raw);
         $this->assertSame($parsed, $path->getUriComponent());
+        $this->assertSame($raw, $path->getContent(Path::RFC3987));
     }
 
     public function validPathEncoding()
@@ -50,6 +51,7 @@ class PathTest extends AbstractTestCase
             ['\\slashy', '%5Cslashy'],
             ['foo^bar', 'foo%5Ebar'],
             ['foo^bar/baz', 'foo%5Ebar/baz'],
+            ['foo%2Fbar', 'foo%2Fbar', 'foo%2Fbar'],
         ];
     }
 
@@ -61,6 +63,12 @@ class PathTest extends AbstractTestCase
     {
         $this->expectException(Exception::class);
         new Path($raw);
+    }
+
+    public function testInvalidEncodingTypeThrowException()
+    {
+        $this->expectException(Exception::class);
+        (new Path('query'))->getContent('RFC1738');
     }
 
     public function invalidDataProvider()

--- a/test/SchemeTest.php
+++ b/test/SchemeTest.php
@@ -90,4 +90,10 @@ class SchemeTest extends AbstractTestCase
             'array' => [['foo']],
         ];
     }
+
+    public function testInvalidEncodingTypeThrowException()
+    {
+        $this->expectException(Exception::class);
+        (new Scheme('http'))->getContent('RFC1738');
+    }
 }


### PR DESCRIPTION
All components exposes a "toIRI" method to convert the component content
encoding from RFC3986 to RFC3987

Introduce Query::RFC3986 and Query::RFC3987 constant
to enable selection the encoding type for the public static Query::build method