### PR TITLE
Add the possibility to inject a Domain resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 - The domain resolver as a Rules object is now injecting into the Host domain so that its data can be cached independently of the filecache. If not domain resolver is provided the Host will fallback to using the filecache with the data being kept for 7 days in a `vendor` subdirectory.
 
+- Decoupled the `QueryBuilder` and the `QueryParser` from `ComponentTrait`
+
 ### Deprecated
 
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All Notable changes to `League\Uri\Components` will be documented in this file
 
+## 1.7.0 - 2018-01-30
+
+### Added
+
+- Adding the possibility to use your own domain resolver object.
+    - `Host::__construct` can take an optional `Rules` object as the domain resolver
+    - `Host::createFromIp` can take an optional `Rules` object as the domain resolver
+    - `Host::createFromLabels` can take an optional `Rules` object as the domain resolver
+    - `Host::withDomainResolver` to enable switching to current domain resolver object
+
+### Fixed
+
+- The domain resolver as a Rules object is now injecting into the Host domain so that its data can be cached independently of the filecache. If not domain resolver is provided the Host will fallback to using the filecache with the data being kept for 7 days in a `vendor` subdirectory.
+
+### Deprecated
+
+- None
+
+### Remove
+
+- None
+
 ## 1.6.0 - 2017-12-05
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-fileinfo": "*",
         "ext-intl": "*",
         "ext-mbstring": "*",
-        "league/uri-hostname-parser": "^1.0.4"
+        "league/uri-hostname-parser": "^1.1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.3",

--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/AbstractHierarchicalComponent.php
+++ b/src/Components/AbstractHierarchicalComponent.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE
@@ -92,7 +92,7 @@ abstract class AbstractHierarchicalComponent implements Countable, IteratorAggre
     /**
      * {@inheritdoc}
      */
-    abstract public function getContent(int $enc_type = ComponentInterface::RFC3986_ENCODING);
+    abstract public function getContent(int $enc_type = EncodingInterface::RFC3986_ENCODING);
 
     /**
      * {@inheritdoc}

--- a/src/Components/ComponentInterface.php
+++ b/src/Components/ComponentInterface.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-interfaces/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-interfaces/
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/ComponentTrait.php
+++ b/src/Components/ComponentTrait.php
@@ -93,9 +93,7 @@ trait ComponentTrait
             return rawurlencode($matches[0]);
         };
 
-        $res = preg_replace_callback($regexp, $encoder, $str);
-
-        return $res ?? rawurlencode($str);
+        return preg_replace_callback($regexp, $encoder, $str) ?? rawurlencode($str);
     }
 
     /**

--- a/src/Components/ComponentTrait.php
+++ b/src/Components/ComponentTrait.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE
@@ -94,11 +94,8 @@ trait ComponentTrait
         };
 
         $res = preg_replace_callback($regexp, $encoder, $str);
-        if (null !== $res) {
-            return $res;
-        }
 
-        return rawurlencode($str);
+        return $res ?? rawurlencode($str);
     }
 
     /**

--- a/src/Components/DataPath.php
+++ b/src/Components/DataPath.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/EncodingInterface.php
+++ b/src/Components/EncodingInterface.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-interfaces/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-interfaces/
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/Exception.php
+++ b/src/Components/Exception.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/Fragment.php
+++ b/src/Components/Fragment.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE
@@ -36,7 +36,7 @@ class Fragment extends AbstractComponent
     /**
      * {@inheritdoc}
      */
-    public function getContent(int $enc_type = ComponentInterface::RFC3986_ENCODING)
+    public function getContent(int $enc_type = self::RFC3986_ENCODING)
     {
         $this->assertValidEncoding($enc_type);
 
@@ -44,7 +44,7 @@ class Fragment extends AbstractComponent
             return $this->data;
         }
 
-        if (ComponentInterface::RFC3987_ENCODING == $enc_type) {
+        if (self::RFC3987_ENCODING == $enc_type) {
             $pattern = str_split(self::$invalid_uri_chars);
 
             return str_replace($pattern, array_map('rawurlencode', $pattern), $this->data);
@@ -53,7 +53,7 @@ class Fragment extends AbstractComponent
         $regexp = '/(?:[^'.self::$unreserved_chars.self::$subdelim_chars.'\:\/@\?]+|%(?!'.self::$encoded_chars.'))/ux';
 
         $content = $this->encode($this->data, $regexp);
-        if (ComponentInterface::RFC1738_ENCODING == $enc_type) {
+        if (self::RFC1738_ENCODING == $enc_type) {
             return $this->toRFC1738($content);
         }
 

--- a/src/Components/HierarchicalPath.php
+++ b/src/Components/HierarchicalPath.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/Path.php
+++ b/src/Components/Path.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/PathInfoTrait.php
+++ b/src/Components/PathInfoTrait.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE
@@ -96,11 +96,11 @@ trait PathInfoTrait
      *
      * @return string|null
      */
-    public function getContent(int $enc_type = ComponentInterface::RFC3986_ENCODING)
+    public function getContent(int $enc_type = EncodingInterface::RFC3986_ENCODING)
     {
         $this->assertValidEncoding($enc_type);
 
-        if ($enc_type == ComponentInterface::RFC3987_ENCODING) {
+        if ($enc_type == EncodingInterface::RFC3987_ENCODING) {
             $pattern = str_split(self::$invalid_uri_chars);
             $pattern[] = '#';
             $pattern[] = '?';
@@ -108,11 +108,11 @@ trait PathInfoTrait
             return str_replace($pattern, array_map('rawurlencode', $pattern), $this->getDecoded());
         }
 
-        if ($enc_type == ComponentInterface::RFC3986_ENCODING) {
+        if ($enc_type == EncodingInterface::RFC3986_ENCODING) {
             return $this->encodePath($this->getDecoded());
         }
 
-        if ($enc_type == ComponentInterface::RFC1738_ENCODING) {
+        if ($enc_type == EncodingInterface::RFC1738_ENCODING) {
             return $this->toRFC1738($this->encodePath($this->getDecoded()));
         }
 

--- a/src/Components/Port.php
+++ b/src/Components/Port.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/Query.php
+++ b/src/Components/Query.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE
@@ -92,7 +92,7 @@ class Query implements ComponentInterface, Countable, IteratorAggregate
     public static function extract(
         string $str,
         string $separator = '&',
-        int $enc_type = ComponentInterface::RFC3986_ENCODING
+        int $enc_type = self::RFC3986_ENCODING
     ): array {
         return Uri\extract_query($str, $separator, $enc_type);
     }
@@ -114,7 +114,7 @@ class Query implements ComponentInterface, Countable, IteratorAggregate
     public static function parse(
         string $str,
         string $separator = '&',
-        int $enc_type = ComponentInterface::RFC3986_ENCODING
+        int $enc_type = self::RFC3986_ENCODING
     ): array {
         return Uri\parse_query($str, $separator, $enc_type);
     }
@@ -136,7 +136,7 @@ class Query implements ComponentInterface, Countable, IteratorAggregate
     public static function build(
         $pairs,
         string $separator = '&',
-        int $enc_type = Query::RFC3986_ENCODING
+        int $enc_type = self::RFC3986_ENCODING
     ): string {
         return Uri\build_query($pairs, $separator, $enc_type);
     }
@@ -288,7 +288,7 @@ class Query implements ComponentInterface, Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getContent(int $enc_type = ComponentInterface::RFC3986_ENCODING)
+    public function getContent(int $enc_type = self::RFC3986_ENCODING)
     {
         $this->assertValidEncoding($enc_type);
         if (!$this->preserve_delimiter) {

--- a/src/Components/Scheme.php
+++ b/src/Components/Scheme.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Components/UserInfo.php
+++ b/src/Components/UserInfo.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE
@@ -133,14 +133,14 @@ class UserInfo implements ComponentInterface
      *
      * @return string|null
      */
-    public function getUser(int $enc_type = ComponentInterface::RFC3986_ENCODING)
+    public function getUser(int $enc_type = self::RFC3986_ENCODING)
     {
         $this->assertValidEncoding($enc_type);
-        if ('' == $this->user || ComponentInterface::NO_ENCODING == $enc_type) {
+        if ('' == $this->user || self::NO_ENCODING == $enc_type) {
             return $this->user;
         }
 
-        if ($enc_type == ComponentInterface::RFC3987_ENCODING) {
+        if ($enc_type == self::RFC3987_ENCODING) {
             $pattern = array_merge(str_split(self::$invalid_uri_chars), ['/', '#', '?', ':', '@']);
 
             return str_replace($pattern, array_map('rawurlencode', $pattern), $this->user);
@@ -148,7 +148,7 @@ class UserInfo implements ComponentInterface
 
         $regexp = '/(?:[^'.static::$unreserved_chars.static::$subdelim_chars.']+|%(?!'.static::$encoded_chars.'))/x';
 
-        if (ComponentInterface::RFC1738_ENCODING == $enc_type) {
+        if (self::RFC1738_ENCODING == $enc_type) {
             return $this->toRFC1738($this->encode($this->user, $regexp));
         }
 
@@ -162,14 +162,14 @@ class UserInfo implements ComponentInterface
      *
      * @return string|null
      */
-    public function getPass(int $enc_type = ComponentInterface::RFC3986_ENCODING)
+    public function getPass(int $enc_type = self::RFC3986_ENCODING)
     {
         $this->assertValidEncoding($enc_type);
-        if ('' == $this->pass || ComponentInterface::NO_ENCODING == $enc_type) {
+        if ('' == $this->pass || self::NO_ENCODING == $enc_type) {
             return $this->pass;
         }
 
-        if ($enc_type == ComponentInterface::RFC3987_ENCODING) {
+        if ($enc_type == self::RFC3987_ENCODING) {
             $pattern = array_merge(str_split(self::$invalid_uri_chars), ['/', '#', '?', '@']);
 
             return str_replace($pattern, array_map('rawurlencode', $pattern), $this->pass);
@@ -177,7 +177,7 @@ class UserInfo implements ComponentInterface
 
         $regexp = '/(?:[^'.static::$unreserved_chars.static::$subdelim_chars.']+|%(?!'.static::$encoded_chars.'))/x';
 
-        if (ComponentInterface::RFC1738_ENCODING == $enc_type) {
+        if (self::RFC1738_ENCODING == $enc_type) {
             return $this->toRFC1738($this->encode($this->pass, $regexp));
         }
 
@@ -195,7 +195,7 @@ class UserInfo implements ComponentInterface
     /**
      * {@inheritdoc}
      */
-    public function getContent(int $enc_type = ComponentInterface::RFC3986_ENCODING)
+    public function getContent(int $enc_type = self::RFC3986_ENCODING)
     {
         $this->assertValidEncoding($enc_type);
         if (null === $this->user) {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/QueryParser.php
+++ b/src/QueryParser.php
@@ -6,7 +6,7 @@
  * @subpackage League\Uri\Components
  * @author     Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @license    https://github.com/thephpleague/uri-components/blob/master/LICENSE (MIT License)
- * @version    1.6.0
+ * @version    1.7.0
  * @link       https://github.com/thephpleague/uri-components
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/Components/HostTest.php
+++ b/tests/Components/HostTest.php
@@ -5,6 +5,9 @@ namespace LeagueTest\Uri\Components;
 use ArrayIterator;
 use League\Uri\Components\Exception;
 use League\Uri\Components\Host;
+use League\Uri\PublicSuffix\Cache;
+use League\Uri\PublicSuffix\CurlHttpClient;
+use League\Uri\PublicSuffix\ICANNSectionManager;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 
@@ -39,6 +42,14 @@ class HostTest extends TestCase
         $host = new Host('uri.thephpleague.com');
         $alt_host = $host->withContent('uri.thephpleague.com');
         $this->assertSame($alt_host, $host);
+    }
+
+    public function testWithDomainResolver()
+    {
+        $resolver = (new ICANNSectionManager(new Cache(), new CurlHttpClient()))->getRules();
+        $host = new Host('uri.thephpleague.com');
+        $newHost = $host->withDomainResolver($resolver);
+        $this->assertEquals($newHost, $host);
     }
 
     /**

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -15,6 +15,18 @@ use TypeError;
  */
 class FunctionsTest extends TestCase
 {
+    public function testEncodingThrowsExceptionWithQueryParser()
+    {
+        $this->expectException(Exception::class);
+        Uri\parse_query('foo=bar', '&', 42);
+    }
+
+    public function testEncodingThrowsExceptionWithQueryBuilder()
+    {
+        $this->expectException(Exception::class);
+        Uri\build_query(['foo' => 'bar'], '&', 42);
+    }
+
     public function testQuerParserConvert()
     {
         $expected = ['a' => ['1', '2', 'false']];


### PR DESCRIPTION
## Introduction

Adding a way to inject the domain resolver into the Host and remove the hardcoded dependency on a specific domain resolver instantiation.

## Proposal

The Host constructor and named constructors will be modified to enable the user to supply his/her own Rule object on instantiation so to not rely on the following default construct

### Describe the new/upated/fixed feature

[see issue](https://github.com/thephpleague/uri-hostname-parser/issues/2)

> I've league/uri-hostname-parser downloaded as a dependency and my vendor directory is not writable, so the cache used by the default manager created in League\Uri\resolve_domain function throws an exception. How can I change the manager which is being used there?

We will add the following option to the methods

```php

Host::createFromLabels(array $labels, int $encode_type, Rules $resolver = null);
Host::createFromIp(string $ip, Rules $resolver = null);
Host::__construct(string $host = null, Rules $resolver = null);
Host::withResolver(Rules $resolver): static
```

### Backward Incompatible Changes

None. If no Resolver is specified the class will fallback to its current behavior generate a Rules from the Filesystem cache found in the vendor subdirectory if possible and will throws if it is not possible.

### Targeted release version

1.7.0

### PR Impact

The public API is changed by adding a new optional argument to methods.

## Open issues

Would be great if the resolver followed some kind of PSR or common interface to allow other domain resolver like PHP Domain parser or TLDExtract to be used instead of league own implementation.
