### PR TITLE
Bugfix Host component

### DIFF
--- a/src/Components/HierarchicalPath.php
+++ b/src/Components/HierarchicalPath.php
@@ -455,9 +455,9 @@ class HierarchicalPath extends AbstractHierarchicalComponent implements Componen
         string $extension,
         string $parameterPart = null
     ): string {
-        $length = mb_strrpos($basenamePart, '.'.pathinfo($basenamePart, PATHINFO_EXTENSION), 'UTF-8');
+        $length = strrpos($basenamePart, '.'.pathinfo($basenamePart, PATHINFO_EXTENSION));
         if (false !== $length) {
-            $basenamePart = mb_substr($basenamePart, 0, $length, 'UTF-8');
+            $basenamePart = substr($basenamePart, 0, $length);
         }
 
         $parameterPart = trim((string) $parameterPart);

--- a/src/Components/Host.php
+++ b/src/Components/Host.php
@@ -54,14 +54,9 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
     protected $host_as_domain_name = false;
 
     /**
-     * Tell whether the Host is an IPFuture
-     *
-     * @var bool
-     */
-    protected $host_as_ipfuture = false;
-
-    /**
      * Tell whether the Host is an IPv4
+     *
+     * @deprecated 1.8.0 No longer used by internal code and not recommend
      *
      * @var bool
      */
@@ -69,6 +64,8 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
 
     /**
      * Tell whether the Host is an IPv6
+     *
+     * @deprecated 1.8.0 No longer used by internal code and not recommend
      *
      * @var bool
      */
@@ -164,7 +161,7 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.8.0
+     * @deprecated 1.8.0 No longer used by internal code and not recommend
      *
      * @param array $data The segments list
      * @param int   $type
@@ -266,7 +263,6 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
         }
 
         if ($this->isValidIpFuture($host)) {
-            $this->host_as_ipfuture = true;
             preg_match('/^v(?<version>[A-F0-9]+)\./', substr($host, 1, -1), $matches);
             $this->ip_version = $matches['version'];
 
@@ -279,12 +275,16 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
     /**
      * Set the FQDN property.
      *
-     * @param string $str
+     * @param string|null $str
      *
-     * @return string
+     * @return string|null
      */
-    protected function setIsAbsolute(string $str)
+    protected function setIsAbsolute(string $str = null)
     {
+        if (null === $str) {
+            return $str;
+        }
+
         $this->is_absolute = self::IS_RELATIVE;
         if ('.' === substr($str, -1, 1)) {
             $this->is_absolute = self::IS_ABSOLUTE;
@@ -435,7 +435,7 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.8.0
+     * @deprecated 1.8.0 No longer used by internal code and not recommend
      *
      * A valid registered name MUST:
      *
@@ -464,7 +464,7 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.8.0
+     * @deprecated 1.8.0 No longer used by internal code and not recommend
      *
      * A valid registered name label MUST:
      *
@@ -555,7 +555,7 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.5.0
+     * @deprecated 1.5.0 Typo fix in name
      * @see        Host::getRegistrableDomain
      *
      * @return string
@@ -666,7 +666,7 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
      */
     public function isIpFuture(): bool
     {
-        return $this->host_as_ipfuture;
+        return !in_array($this->ip_version, [null, '4', '6'], true);
     }
 
     /**
@@ -806,19 +806,19 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
      */
     public function getIp()
     {
-        if ($this->host_as_ipv4) {
-            return $this->data[0];
-        }
-
-        if ($this->host_as_ipfuture) {
-            return preg_replace('/^v(?<version>[A-F0-9]+)\./', '', substr($this->data[0], 1, -1));
-        }
-
-        if (!$this->host_as_ipv6) {
+        if (null === $this->ip_version) {
             return null;
         }
 
+        if ('4' === $this->ip_version) {
+            return $this->data[0];
+        }
+
         $ip = substr($this->data[0], 1, -1);
+        if ('6' !== $this->ip_version) {
+            return preg_replace('/^v(?<version>[A-F0-9]+)\./', '', $ip);
+        }
+
         if (false === ($pos = strpos($ip, '%'))) {
             return $ip;
         }
@@ -1137,7 +1137,7 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.5.0
+     * @deprecated 1.5.0 Typo fix in name
      * @see        Host::withRegistrableDomain
      *
      * @param string $host the registerable domain to add

--- a/src/Components/Host.php
+++ b/src/Components/Host.php
@@ -760,7 +760,7 @@ class Host extends AbstractHierarchicalComponent implements ComponentInterface
             return null;
         }
 
-        if ($this->isIp() || !$this->isDomain()) {
+        if (!$this->host_as_domain_name) {
             return $this->data[0];
         }
 

--- a/src/Components/PathInfoTrait.php
+++ b/src/Components/PathInfoTrait.php
@@ -71,7 +71,7 @@ trait PathInfoTrait
     {
         $path = $this->__toString();
 
-        return '' !== $path && '/' === mb_substr($path, 0, 1, 'UTF-8');
+        return '' !== $path && '/' === substr($path, 0, 1);
     }
 
     /**
@@ -238,7 +238,7 @@ trait PathInfoTrait
     {
         $path = $this->__toString();
 
-        return '' !== $path && '/' === mb_substr($path, -1, 1, 'UTF-8');
+        return '' !== $path && '/' === substr($path, -1);
     }
 
     /**
@@ -268,7 +268,7 @@ trait PathInfoTrait
      */
     public function withoutTrailingSlash()
     {
-        return !$this->hasTrailingSlash() ? $this : $this->withContent(mb_substr($this->__toString(), 0, -1, 'UTF-8'));
+        return !$this->hasTrailingSlash() ? $this : $this->withContent(substr($this->__toString(), 0, -1));
     }
 
     /**
@@ -298,6 +298,6 @@ trait PathInfoTrait
      */
     public function withoutLeadingSlash()
     {
-        return !$this->isAbsolute() ? $this : $this->withContent(mb_substr($this->__toString(), 1, null, 'UTF-8'));
+        return !$this->isAbsolute() ? $this : $this->withContent(substr($this->__toString(), 1));
     }
 }

--- a/src/Components/Query.php
+++ b/src/Components/Query.php
@@ -80,7 +80,7 @@ class Query implements ComponentInterface, Countable, IteratorAggregate
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.5.0
+     * @deprecated 1.5.0 No longer used by internal code and not recommend
      * @see        \League\Uri\QueryParser::extract
      *
      * @param string $str       the query string
@@ -102,7 +102,7 @@ class Query implements ComponentInterface, Countable, IteratorAggregate
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.5.0
+     * @deprecated 1.5.0 No longer used by internal code and not recommend
      * @see        \League\Uri\QueryParser::parse
      *
      * @param string $str       The query string to parse
@@ -124,7 +124,7 @@ class Query implements ComponentInterface, Countable, IteratorAggregate
      *
      * DEPRECATION WARNING! This method will be removed in the next major point release
      *
-     * @deprecated deprecated since version 1.5.0
+     * @deprecated 1.5.0 No longer used by internal code and not recommend
      * @see        \League\Uri\QueryBuilder::build
      *
      * @param array|Traversable $pairs     Query pairs

--- a/tests/Components/HostTest.php
+++ b/tests/Components/HostTest.php
@@ -61,12 +61,13 @@ class HostTest extends TestCase
      * @param bool        $isIpv4
      * @param bool        $isIpv6
      * @param bool        $isIpFuture
+     * @param string|null $ipVersion
      * @param string      $uri
      * @param string      $ip
      * @param string      $iri
      * @dataProvider validHostProvider
      */
-    public function testValidHost($host, $isDomain, $isIp, $isIpv4, $isIpv6, $isIpFuture, $uri, $ip, $iri)
+    public function testValidHost($host, $isDomain, $isIp, $isIpv4, $isIpv6, $isIpFuture, $ipVersion, $uri, $ip, $iri)
     {
         $host = new Host($host);
         $this->assertSame($isDomain, $host->isDomain());
@@ -77,6 +78,7 @@ class HostTest extends TestCase
         $this->assertSame($uri, $host->getUriComponent());
         $this->assertSame($ip, $host->getIp());
         $this->assertSame($iri, $host->getContent(Host::RFC3987_ENCODING));
+        $this->assertSame($ipVersion, $host->getIpVersion());
     }
 
     public function validHostProvider()
@@ -89,6 +91,7 @@ class HostTest extends TestCase
                 true,
                 false,
                 false,
+                '4',
                 '127.0.0.1',
                 '127.0.0.1',
                 '127.0.0.1',
@@ -100,6 +103,7 @@ class HostTest extends TestCase
                 false,
                 true,
                 false,
+                '6',
                 '[::1]',
                 '::1',
                 '[::1]',
@@ -111,6 +115,7 @@ class HostTest extends TestCase
                 false,
                 true,
                 false,
+                '6',
                 '[fe80:1234::%251]',
                 'fe80:1234::%1',
                 '[fe80:1234::%251]',
@@ -122,8 +127,9 @@ class HostTest extends TestCase
                 false,
                 false,
                 true,
+                '1',
                 '[v1.ZZ.ZZ]',
-                'v1.ZZ.ZZ',
+                'ZZ.ZZ',
                 '[v1.ZZ.ZZ]',
             ],
             'normalized' => [
@@ -133,6 +139,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 'master.example.com',
                 null,
                 'master.example.com',
@@ -144,6 +151,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 '',
                 null,
                 '',
@@ -155,6 +163,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 '',
                 null,
                 null,
@@ -166,6 +175,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 'example.com.',
                 null,
                 'example.com.',
@@ -177,6 +187,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 '23.42c.two',
                 null,
                 '23.42c.two',
@@ -188,6 +199,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 '98.3.2',
                 null,
                 '98.3.2',
@@ -199,6 +211,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 'toto.127.0.0.1',
                 null,
                 'toto.127.0.0.1',
@@ -210,6 +223,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 'xn--mgbh0fb.xn--kgbechtv',
                 null,
                 'مثال.إختبار',
@@ -221,6 +235,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 'xn--mgbh0fb.xn--kgbechtv',
                 null,
                 'مثال.إختبار',
@@ -232,6 +247,7 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                null,
                 'test..example.com',
                 null,
                 'test..example.com',

--- a/tests/Components/HostTest.php
+++ b/tests/Components/HostTest.php
@@ -59,17 +59,19 @@ class HostTest extends TestCase
      * @param bool        $isIp
      * @param bool        $isIpv4
      * @param bool        $isIpv6
+     * @param bool        $isIpFuture
      * @param string      $uri
      * @param string      $ip
      * @param string      $iri
      * @dataProvider validHostProvider
      */
-    public function testValidHost($host, $isIp, $isIpv4, $isIpv6, $uri, $ip, $iri)
+    public function testValidHost($host, $isIp, $isIpv4, $isIpv6, $isIpFuture, $uri, $ip, $iri)
     {
         $host = new Host($host);
         $this->assertSame($isIp, $host->isIp());
         $this->assertSame($isIpv4, $host->isIpv4());
         $this->assertSame($isIpv6, $host->isIpv6());
+        $this->assertSame($isIpFuture, $host->isIpFuture());
         $this->assertSame($uri, $host->getUriComponent());
         $this->assertSame($ip, $host->getIp());
         $this->assertSame($iri, $host->getContent(Host::RFC3987_ENCODING));
@@ -83,6 +85,7 @@ class HostTest extends TestCase
                 true,
                 true,
                 false,
+                false,
                 '127.0.0.1',
                 '127.0.0.1',
                 '127.0.0.1',
@@ -92,6 +95,7 @@ class HostTest extends TestCase
                 true,
                 false,
                 true,
+                false,
                 '[::1]',
                 '::1',
                 '[::1]',
@@ -101,12 +105,24 @@ class HostTest extends TestCase
                 true,
                 false,
                 true,
+                false,
                 '[fe80:1234::%251]',
                 'fe80:1234::%1',
                 '[fe80:1234::%251]',
             ],
+            'ipfuture' => [
+                '[v1.ZZ.ZZ]',
+                true,
+                false,
+                false,
+                true,
+                '[v1.ZZ.ZZ]',
+                'v1.ZZ.ZZ',
+                '[v1.ZZ.ZZ]',
+            ],
             'normalized' => [
                 'Master.EXAMPLE.cOm',
+                false,
                 false,
                 false,
                 false,
@@ -119,12 +135,14 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                false,
                 '',
                 null,
                 '',
             ],
             'null' => [
                 null,
+                false,
                 false,
                 false,
                 false,
@@ -137,12 +155,14 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                false,
                 'example.com.',
                 null,
                 'example.com.',
             ],
             'partial numeric' => [
                 '23.42c.two',
+                false,
                 false,
                 false,
                 false,
@@ -155,12 +175,14 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                false,
                 '98.3.2',
                 null,
                 '98.3.2',
             ],
             'mix IP format with host label' => [
                 'toto.127.0.0.1',
+                false,
                 false,
                 false,
                 false,
@@ -173,12 +195,14 @@ class HostTest extends TestCase
                 false,
                 false,
                 false,
+                false,
                 'xn--mgbh0fb.xn--kgbechtv',
                 null,
                 'مثال.إختبار',
             ],
             'IRI support' => [
                 'xn--mgbh0fb.xn--kgbechtv',
+                false,
                 false,
                 false,
                 false,
@@ -231,6 +255,7 @@ class HostTest extends TestCase
             'invalid scope IPv6' => ['[ab23::1234%251]'],
             'invalid scope ID' => ['[fe80::1234%25?@]'],
             'invalid scope ID with utf8 character' => ['[fe80::1234%25€]'],
+            'invalid IPFuture' => ['[v4.1.2.3]'],
         ];
     }
 
@@ -388,6 +413,7 @@ class HostTest extends TestCase
             'ipv4' => ['127.0.0.1', '127.0.0.1'],
             'ipv6' => ['::1', '[::1]'],
             'ipv6 with scope' => ['fe80:1234::%1', '[fe80:1234::%251]'],
+            'valid IpFuture' => ['vAF.csucj.$&+;::', '[vAF.csucj.$&+;::]'],
         ];
     }
 
@@ -406,6 +432,7 @@ class HostTest extends TestCase
         return [
             'false ipv4' => ['127.0.0'],
             'hostname' => ['example.com'],
+            'false ipfuture' => ['vAF.csucj.$&+;:/:'],
         ];
     }
 


### PR DESCRIPTION
Let's improve Host compliance to RFC3986 like what we did on uri-schemes. The following hosts that were previously invalid like `example....com` are now valid whereas host like `_b%C3%A9bé.be-` are now made invalid to better conform to RFC3986. In other words:

- Host validation and formatting is improved (valid registered name which are not domain are now supported);
- IPvFuture support is added as well;

The following methods are added

- `Host::isDomain`
- `Host::isIpFuture`
- `Host::getIpVersion`

The following internal methods are deprecated:

- `Host::format`
- `Host::isValidHostname`
- `Host::isValidLabel`

The Host public API can now categorized all type of hosts with the following methods:

- `Host::isIp`
- `Host::isIpv4`
- `Host::isIpv6`
- `Host::isIpFuture`
- `Host::isDomain`

If a Host is not an IP it is simply a registered name.

