### PR TITLE
Bug fix userinfo component decoded

### DIFF
--- a/src/Components/UserInfo.php
+++ b/src/Components/UserInfo.php
@@ -25,11 +25,19 @@ use League\Uri\Contracts\UserInfoInterface;
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
 use TypeError;
 use function explode;
+use function preg_match;
+use function preg_replace_callback;
+use function rawurldecode;
 use function sprintf;
+use function strtoupper;
 
 final class UserInfo extends Component implements UserInfoInterface
 {
-    private const REGEXP_USERINFO_ENCODING = '/(?:[^A-Za-z0-9_\-\.~\!\$&\'\(\)\*\+,;\=%]+|%(?![A-Fa-f0-9]{2}))/x';
+    private const REGEXP_USER_ENCODING = '/(?:[^A-Za-z0-9_\-\.~\!\$&\'\(\)\*\+,;\=%]+|%(?![A-Fa-f0-9]{2}))/x';
+
+    private const REGEXP_PASS_ENCODING = '/(?:[^A-Za-z0-9_\-\.~\!\$&\'\(\)\*\+,;\=%\:]+|%(?![A-Fa-f0-9]{2}))/x';
+
+    private const REGEXP_UNRESERVED_CHAR = ',%[A-Fa-f0-9]{2},';
 
     /**
      * @var string|null
@@ -79,9 +87,7 @@ final class UserInfo extends Component implements UserInfoInterface
                 return new self();
             }
 
-            $params = explode(':', $component, 2) + [1 => null];
-
-            return new self(...$params);
+            return self::createFromComponent($component);
         }
 
         if (!$uri instanceof Psr7UriInterface) {
@@ -93,9 +99,7 @@ final class UserInfo extends Component implements UserInfoInterface
             return new self();
         }
 
-        $params = explode(':', $component, 2) + [1 => null];
-
-        return new self(...$params);
+        return self::createFromComponent($component);
     }
 
     /**
@@ -108,9 +112,40 @@ final class UserInfo extends Component implements UserInfoInterface
             return new self();
         }
 
+        return self::createFromComponent($userInfo);
+    }
+
+    /**
+     * Creates a new instance from a encoded string.
+     */
+    private static function createFromComponent(string $userInfo): self
+    {
         [$user, $pass] = explode(':', $userInfo, 2) + [1 => null];
+        if (null !== $user) {
+            $user = self::decode($user, self::REGEXP_USER_ENCODING);
+        }
+
+        if (null !== $pass) {
+            $pass = self::decode($pass, self::REGEXP_PASS_ENCODING);
+        }
 
         return new self($user, $pass);
+    }
+
+    /**
+     * Decodes an encoded string.
+     */
+    private static function decode(string $str, string $regexp): ?string
+    {
+        $decoder = function (array $matches) use ($regexp): string {
+            if (1 === preg_match($regexp, $matches[0])) {
+                return strtoupper($matches[0]);
+            }
+
+            return rawurldecode($matches[0]);
+        };
+
+        return preg_replace_callback(self::REGEXP_UNRESERVED_CHAR, $decoder, $str);
     }
 
     /**
@@ -122,12 +157,12 @@ final class UserInfo extends Component implements UserInfoInterface
             return null;
         }
 
-        $userInfo = $this->encodeComponent($this->user, self::REGEXP_USERINFO_ENCODING);
+        $userInfo = $this->encodeComponent($this->user, self::REGEXP_USER_ENCODING);
         if (null === $this->pass) {
             return $userInfo;
         }
 
-        return $userInfo.':'.$this->encodeComponent($this->pass, self::REGEXP_USERINFO_ENCODING);
+        return $userInfo.':'.$this->encodeComponent($this->pass, self::REGEXP_PASS_ENCODING);
     }
 
     /**
@@ -168,9 +203,7 @@ final class UserInfo extends Component implements UserInfoInterface
             return new self();
         }
 
-        $params = explode(':', $content, 2) + [1 => null];
-
-        return new self(...$params);
+        return self::createFromComponent($content);
     }
 
     /**

--- a/tests/Components/UserInfoTest.php
+++ b/tests/Components/UserInfoTest.php
@@ -189,11 +189,11 @@ class UserInfoTest extends TestCase
             'no login but has password' => [null, ':pass', '', null, ''],
             'empty all' => [null, '', '', null, ''],
             'null content' => [null, null, null, null, ''],
-            'encoded chars' => [null, 'foo%40bar:bar%40foo', 'foo@bar', 'bar@foo', 'foo%40bar:bar%40foo'],
             'component interface' => [null, new UserInfo('user', 'pass'), 'user', 'pass', 'user:pass'],
             'reset object' => ['login', new UserInfo(null), null, null, ''],
-            'encoded char 2' => [null, "user:'O=+9zLZ%7D%25%7Bz+:tC", 'user', "'O=+9zLZ}%{z+:tC", "user:'O=+9zLZ%7D%25%7Bz+:tC"],
-
+            'encoded chars 1' => [null, 'foo%40bar:bar%40foo', 'foo@bar', 'bar@foo', 'foo%40bar:bar%40foo'],
+            'encoded chars 3' => [null, 'foo%a1bar:bar%40foo', 'foo%A1bar', 'bar@foo', 'foo%A1bar:bar%40foo'],
+            'encoded chars 2' => [null, "user:'O=+9zLZ%7d%25%7bz+:tC", 'user', "'O=+9zLZ}%{z+:tC", "user:'O=+9zLZ%7D%25%7Bz+:tC"],
         ];
     }
 
@@ -308,6 +308,10 @@ class UserInfoTest extends TestCase
             'League URI object with empty string user info' => [
                 'uri' => Uri::createFromString('http://@example.com?foo=bar'),
                 'expected' => '',
+            ],
+            'URI object with encoded user info string' => [
+                'uri' => Uri::createFromString('http://login%af:bar@example.com:81'),
+                'expected' => 'login%AF:bar',
             ],
         ];
     }

--- a/tests/Components/UserInfoTest.php
+++ b/tests/Components/UserInfoTest.php
@@ -160,6 +160,7 @@ class UserInfoTest extends TestCase
      * @covers ::withContent
      * @covers ::getUser
      * @covers ::getPass
+     * @covers ::decode
      * @covers ::decodeMatches
      *
      * @param mixed|null $str
@@ -191,11 +192,14 @@ class UserInfoTest extends TestCase
             'encoded chars' => [null, 'foo%40bar:bar%40foo', 'foo@bar', 'bar@foo', 'foo%40bar:bar%40foo'],
             'component interface' => [null, new UserInfo('user', 'pass'), 'user', 'pass', 'user:pass'],
             'reset object' => ['login', new UserInfo(null), null, null, ''],
+            'encoded char 2' => [null, "user:'O=+9zLZ%7D%25%7Bz+:tC", 'user', "'O=+9zLZ}%{z+:tC", "user:'O=+9zLZ%7D%25%7Bz+:tC"],
+
         ];
     }
 
     /**
      * @covers ::withContent
+     * @covers ::decode
      * @covers ::decodeMatches
      */
     public function testWithContentReturnSameInstance(): void
@@ -222,6 +226,7 @@ class UserInfoTest extends TestCase
      *
      * @covers ::withUserInfo
      * @covers ::decodeMatches
+     * @covers ::decode
      *
      * @param ?string $pass
      */
@@ -265,6 +270,7 @@ class UserInfoTest extends TestCase
     /**
      * @dataProvider getURIProvider
      * @covers ::createFromUri
+     * @covers ::decode
      *
      * @param mixed   $uri      an URI object
      * @param ?string $expected


### PR DESCRIPTION
try to resolve thephpleague/uri-src#89 

The following methods expect encoded components:

- `UserInfo::createFromUri`;
- `UserInfo::createFromAuthority`;
- `UserInfo::withContent`;

The expected data is supposed to be encoded and decoding will be done as to avoid double encoding.


The following methods expect decode components

- `UserInfo::__construct`;
- `UserInfo::withUserInfo`;

Expects input data will only be encoded on usage with say methods (getUriComponent, getContent)


Last but not least, 

- `UserInfo::getUser`;
- `UserInfo::getPass`;

should always show decoded information.