### PR TITLE
Remove . from phpstan files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,8 @@
 /.github             export-ignore
 /.gitignore          export-ignore
 /.php_cs             export-ignore
-/.phpstan.src.neon   export-ignore
-/.phpstan.tests.neon export-ignore
+/phpstan.src.neon   export-ignore
+/phpstan.tests.neon export-ignore
 /.scrutinizer.yml    export-ignore
 /.travis.yml         export-ignore
 /CONDUCT.md          export-ignore


### PR DESCRIPTION
I'm not sure if you actually want this, or if you want to move the phpstan files to the . prefixed names as per .gitattributes?