### PR TITLE
add test case for url in query param

### DIFF
--- a/tests/QueryStringTest.php
+++ b/tests/QueryStringTest.php
@@ -393,6 +393,11 @@ class QueryStringTest extends TestCase
                 'expected_rfc1738' => 'toto=foo%2Bbar',
                 'expected_rfc3986' => 'toto=foo+bar',
             ],
+            'url in value' => [
+                'pairs' => [['url', 'https://uri.thephpleague.com/components/2.0/?module=home#what-you-will-be-able-to-do with space']],
+                'expected_rfc1738' => 'url=https%3A%2F%2Furi.thephpleague.com%2Fcomponents%2F2.0%2Fmodule%3Dhome%23what-you-will-be-able-to-do+with+space',
+                'expected_rfc3986' => 'url=https%3A%2F%2Furi.thephpleague.com%2Fcomponents%2F2.0%2Fmodule%3Dhome%23what-you-will-be-able-to-do%20with%20space',
+            ],
         ];
     }
 


### PR DESCRIPTION
Today I've encountered a problem with query building when one of the parameters is another url.
I've added tests at first to confirm the problem and briefly went step by step through xdebug. It looks like there could be problem in `QueryString` methods `buildPair` or `encodeMatches`. 

rfc1738 (problem with `=` equals sign)
```
--- Expected
+++ Actual
@@ @@
-'url=https%3A%2F%2Furi.thephpleague.com%2Fcomponents%2F2.0%2F%3Fmodule%3Dhome%23what-you-will-be-able-to-do+with+space'
+'url=https%3A%2F%2Furi.thephpleague.com%2Fcomponents%2F2.0%2F%3Fmodule=home%23what-you-will-be-able-to-do+with+space'
```

rfc3986 (problem with almost whole parameter)
```
--- Expected
+++ Actual
@@ @@
-'url=https%3A%2F%2Furi.thephpleague.com%2Fcomponents%2F2.0%2F%3Fmodule%3Dhome%23what-you-will-be-able-to-do%20with%20space'
+'url=https://uri.thephpleague.com/components/2.0/?module=home%23what-you-will-be-able-to-do%20with%20space'
```