### PR TITLE
Deal with binary string

### DIFF
--- a/src/Components/DataPath.php
+++ b/src/Components/DataPath.php
@@ -283,11 +283,13 @@ final class DataPath extends Component implements DataPathInterface
             $mime_args[] = $context;
         }
 
+        /** @phpstan-ignore-next-line */
         $content = @file_get_contents(...$file_args);
         if (false === $content) {
             throw new SyntaxError(sprintf('`%s` failed to open stream: No such file or directory.', $path));
         }
 
+        /** @phpstan-ignore-next-line */
         $mimetype = (string) (new \finfo(FILEINFO_MIME))->file(...$mime_args);
 
         return new self(

--- a/src/QueryString.php
+++ b/src/QueryString.php
@@ -406,10 +406,10 @@ final class QueryString
         }
 
         // Strip out invalid chars from the key.
-        $name = \preg_replace(self::REGEXP_INVALID_CHARS, '', $name);
+        $name = (string) \preg_replace(self::REGEXP_INVALID_CHARS, '', $name);
 
         // Strip out invalid chars from the value.
-        $value = \preg_replace(self::REGEXP_INVALID_CHARS, '', $value);
+        $value = (string) \preg_replace(self::REGEXP_INVALID_CHARS, '', $value);
 
         $left_bracket_pos = strpos($name, '[');
         if (false === $left_bracket_pos) {

--- a/src/QueryString.php
+++ b/src/QueryString.php
@@ -191,9 +191,6 @@ final class QueryString
             $key = (string) preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $key);
         }
 
-        // Strip out invalid chars from the key.
-        $key = \preg_replace(self::REGEXP_INVALID_CHARS, '', $key);
-
         if (null === $value) {
             return [$key, $value];
         }
@@ -201,9 +198,6 @@ final class QueryString
         if ($parseValue === self::DECODE_PAIR_VALUE && 1 === preg_match(self::REGEXP_ENCODED_PATTERN, $value)) {
             $value = preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $value);
         }
-
-        // Strip out invalid chars from the value.
-        $value = \preg_replace(self::REGEXP_INVALID_CHARS, '', $value);
 
         return [$key, $value];
     }
@@ -410,6 +404,12 @@ final class QueryString
         if ('' === $name) {
             return $data;
         }
+
+        // Strip out invalid chars from the key.
+        $name = \preg_replace(self::REGEXP_INVALID_CHARS, '', $name);
+
+        // Strip out invalid chars from the value.
+        $value = \preg_replace(self::REGEXP_INVALID_CHARS, '', $value);
 
         $left_bracket_pos = strpos($name, '[');
         if (false === $left_bracket_pos) {

--- a/src/QueryString.php
+++ b/src/QueryString.php
@@ -191,6 +191,9 @@ final class QueryString
             $key = (string) preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $key);
         }
 
+        // Strip out invalid chars from the key.
+        $key = \preg_replace(self::REGEXP_INVALID_CHARS, '', $key);
+
         if (null === $value) {
             return [$key, $value];
         }
@@ -199,14 +202,10 @@ final class QueryString
             $value = preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $value);
         }
 
-        return [
-            \preg_replace(
-                self::REGEXP_INVALID_CHARS,
-                '',
-                $key
-            ),
-            $value,
-        ];
+        // Strip out invalid chars from the value.
+        $value = \preg_replace(self::REGEXP_INVALID_CHARS, '', $value);
+
+        return [$key, $value];
     }
 
     /**

--- a/src/QueryString.php
+++ b/src/QueryString.php
@@ -188,7 +188,7 @@ final class QueryString
         $key = (string) $key;
 
         if (1 === preg_match(self::REGEXP_ENCODED_PATTERN, $key)) {
-            $key = (string) preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $key);
+            $key = preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $key);
         }
 
         if (null === $value) {

--- a/src/QueryString.php
+++ b/src/QueryString.php
@@ -188,7 +188,7 @@ final class QueryString
         $key = (string) $key;
 
         if (1 === preg_match(self::REGEXP_ENCODED_PATTERN, $key)) {
-            $key = preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $key);
+            $key = (string) preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $key);
         }
 
         if (null === $value) {
@@ -199,7 +199,14 @@ final class QueryString
             $value = preg_replace_callback(self::REGEXP_ENCODED_PATTERN, [self::class, 'decodeMatch'], $value);
         }
 
-        return [$key, $value];
+        return [
+            \preg_replace(
+                self::REGEXP_INVALID_CHARS,
+                '',
+                $key
+            ),
+            $value,
+        ];
     }
 
     /**

--- a/tests/QueryStringTest.php
+++ b/tests/QueryStringTest.php
@@ -151,6 +151,12 @@ class QueryStringTest extends TestCase
                     'foo' => ['bar', 'baz'],
                 ],
             ],
+            [
+                'query' => 'a%00b=c',
+                'expected' => [
+                    'ab' => 'c',
+                ],
+            ],
         ];
     }
 

--- a/tests/QueryStringTest.php
+++ b/tests/QueryStringTest.php
@@ -152,9 +152,9 @@ class QueryStringTest extends TestCase
                 ],
             ],
             [
-                'query' => 'a%00b=c',
+                'query' => 'a%00b=a%00b',
                 'expected' => [
-                    'ab' => 'c',
+                    'ab' => 'ab',
                 ],
             ],
         ];


### PR DESCRIPTION
PR originally opened on https://github.com/thephpleague/uri-query-parser/issues/6

Hello,

I'm wondering how such query strings should be handled:

```php
$query = 'a%00b=c';
```

When I extract the parameters, I get a binary string, which is obviously invalid.

Maybe we should add a check to make sure it returns a valid string in those cases ?

I added the following test:

```php
            [
                'query' => 'a%00b=c',
                'expected' => [
                    'a' => 'c',
                ]
            ]
```

And the output is:

```
> phpunit --coverage-text
PHPUnit 8.5.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.31 with Xdebug 2.9.5
Configuration: /home/pol/dev/git/uri-query-parser/phpunit.xml

..................F..........................................     61 / 61 (100%)

Time: 310 ms, Memory: 8.00 MB

There was 1 failure:

1) LeagueTest\Uri\QueryStringTest::testExtractQuery with data set #13 ('a%00b=c', array('c'))
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
-    'a' => 'c'
+    Binary String: 0x610062 => 'c'
 )

/home/pol/dev/git/uri-query-parser/tests/QueryStringTest.php:64

FAILURES!
Tests: 61, Assertions: 76, Failures: 1.

Generating code coverage report in Clover XML format ... done [45 ms]

Generating code coverage report in HTML format ... done [36 ms]

```

The result in Firefox:

![image](https://user-images.githubusercontent.com/252042/84887506-20cb5180-b096-11ea-866d-ee67a589a113.png)

The result using \parse_str(): https://3v4l.org/KSdqs

WDYT ?